### PR TITLE
Fixes replacement side effects in data paths.

### DIFF
--- a/src/Repositories/File.php
+++ b/src/Repositories/File.php
@@ -84,7 +84,7 @@ class File implements RepositoryInterface
     {
         if (! isset(self::$paths[$class])) throw new MisconfigurationException($class . ' is not supposed to load data');
 
-        return str_replace(array_keys($params), array_values($params), $prefix . DIRECTORY_SEPARATOR . self::$paths[$class]);
+        return $prefix . DIRECTORY_SEPARATOR . str_replace(array_keys($params), array_values($params), self::$paths[$class]);
     }
 
     /**


### PR DESCRIPTION
Fixes the data path method. In the current state the replacement will replace part of the root path. Example, I'm doing development with docker with the project mounted to `/code` in the container. In it's current state since `code` is in `$params`  the path to the resource which should be `/code/vendor/menerasolutions/geographer-data/resources` is being transformed to `/SOL-III/vendor/menerasolutions/geographer-data/resources` because in `$params` is the key value combo `code` -> `SOL-III`. I believe it's intended that the this substitution only effect the path relative to the root data directory, and this patch fixes that. 