### PR TITLE
 add method merge

### DIFF
--- a/src/Collections/MemberCollection.php
+++ b/src/Collections/MemberCollection.php
@@ -196,4 +196,17 @@ class MemberCollection extends \ArrayObject
     {
         return new static($this->manager, array_slice($this->divisions, $offset, $length, true));
     }
+
+    /**
+     * Merge collections.
+     *
+     * @param  array  $divisions
+     * @return static
+     */
+    public function merge($divisions)
+    {
+        return ($divisions instanceof MemberCollection)
+		? $divisions->merge($this->divisions)
+		: new static($this->manager, array_merge($this->divisions, $divisions));
+    }
 }


### PR DESCRIPTION
Еще 1 полезный метод для коллекций.

Используется например когда нужно вывести список всех городов страны, так как напрямую это сделать нельзя - приходится мержить списки городов всех регионов.

---------------------------

One more useful method for collections.

It can be used to display all cities of the country when you have to merge cities of all regions.