### PR TITLE
Change Divisible::build DocBlock return statement

### DIFF
--- a/src/Divisible.php
+++ b/src/Divisible.php
@@ -194,7 +194,7 @@ abstract class Divisible implements IdentifiableInterface, \ArrayAccess
     /**
      * @param int|string $id
      * @param ManagerInterface $config
-     * @return City
+     * @return City|Country|State
      */
     public static function build($id, $config = null)
     {


### PR DESCRIPTION
The DocBlock comment on the build method suggests only a City will be returned, when it can be a City, Country or State.

It could maybe be changed to `Divisable` but that isn't as helpful, I have also ommitted `Earth` as a return type as for now I don't think people will be using this for other planets.