### PR TITLE
:bug: incorrect return type PHP 8.1

### DIFF
--- a/src/Collections/Traits/ImplementsArray.php
+++ b/src/Collections/Traits/ImplementsArray.php
@@ -38,7 +38,7 @@ trait ImplementsArray
      * @param mixed $value
      * @return mixed
      */
-    public function offsetSet($offset, $value): mixed
+    public function offsetSet($offset, $value): void
     {
         $this->divisions[$offset] = $value;
     }


### PR DESCRIPTION
Hi @dusterio , Thanks for quickly merging my PR! 
Unfortunately there was one minor bug I introduced by specifying the incorrect return type; `mixed` should have been `void` - After this it is no longer triggering any code notices on PHP 8.1+.