### PR TITLE
[BUG]: State::build() with states/divisions with a single character

### DIFF
--- a/src/Repositories/File.php
+++ b/src/Repositories/File.php
@@ -179,7 +179,7 @@ class File implements RepositoryInterface
      */
     protected function getCodeFromIndex($path, $id)
     {
-        if (preg_match('/[A-Z]{2}-[A-Z0-9]{2,3}/', $id) == 1) {
+        if (preg_match('/[A-Z]{2}-[A-Z0-9]{1,3}/', $id) == 1) {
             return substr($id, 0, 2);
         }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/MenaraSolutions/geographer/issues/51

Small description of change:
Trying to look up states with only one character currently throws.

Thanks

